### PR TITLE
print ( string.byte("abc", 2) ) --> 98    instead of   print ( string.byte("abc", 2) ) --> b

### DIFF
--- a/Lua/Lua_Quick_Guide.ipynb
+++ b/Lua/Lua_Quick_Guide.ipynb
@@ -418,7 +418,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print ( string.byte(\"abc\", 2) ) --> b"
+    "print ( string.byte(\"abc\", 2) ) --> 98"
    ]
   },
   {


### PR DESCRIPTION
Should return the ASCII code of 'b'?